### PR TITLE
PEP chart tweaks

### DIFF
--- a/charts/pep-engine/templates/ingress.yaml
+++ b/charts/pep-engine/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
 spec:
   rules:
-  - host: {{ .Values.global.proxyHost | quote }}
+  - host: {{ printf "%s.%s" .Values.context .Values.global.domain | quote }}
     http:
       paths:
       - path: /
@@ -25,7 +25,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
 spec:
   rules:
-  - host: {{ .Values.global.resourceHost | quote }}
+  - host: {{ printf "%s-pepapi.%s" .Values.context .Values.global.domain | quote }}
     http:
       paths:
       - path: /

--- a/charts/pep-engine/templates/pep-deployment.yml
+++ b/charts/pep-engine/templates/pep-deployment.yml
@@ -60,7 +60,7 @@ spec:
             name: {{ .Values.global.pep }}-cm
         volumeMounts:
         - mountPath: /data/db/
-          subPath: {{ .Values.global.pep }}/data/db
+          subPath: {{ .Values.global.pep }}/{{ .Values.context }}/data/db
           name: {{ .Values.volumeClaim.name }}
       hostAliases:
       - ip: {{ .Values.global.nginxIp }}

--- a/charts/pep-engine/templates/pv.yaml
+++ b/charts/pep-engine/templates/pv.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.volumeClaim.create }}
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -12,4 +14,4 @@ spec:
   hostPath:
     path: "/data/"
     type: {{ .Values.persistence.type }}
-
+{{ end }}

--- a/charts/pep-engine/templates/pvc.yaml
+++ b/charts/pep-engine/templates/pvc.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.volumeClaim.create }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -18,3 +20,4 @@ spec:
   selector:
     matchLabels:
       eoepca_type: userman
+{{ end }}

--- a/charts/pep-engine/values.yaml
+++ b/charts/pep-engine/values.yaml
@@ -3,8 +3,6 @@
 global:
   namespace: default
   domain: demoexample.gluu.org
-  proxyHost: http://demoexample.gluu.org/service
-  resourceHost: http://demoexample.gluu.org/res
   pep: pep-engine
   realm: eoepca
   serviceHost: 0.0.0.0
@@ -64,3 +62,4 @@ context: generic
 # VolumeClaim values
 volumeClaim:
   name: um-pep-engine-pvc
+  create: true


### PR DESCRIPTION
- Simplify ingress hosts by using the existing 'context' value
- Fix mount paths to match the current deployments (and the EOEPCA-307 branch approach), in order to use the existing pep persistent data on the NFS server