### PR TITLE
EOEPCA-433 The proxy now has a default value for empty paths #comment…

### DIFF
--- a/charts/pep-engine/scripts/default-resources.json
+++ b/charts/pep-engine/scripts/default-resources.json
@@ -1,6 +1,6 @@
 {
   "default_resources": [
-    {"name": "Base Path", "description": "Base path for Open Access to PEP", "resource_uri": "/", "scopes": ["public_access"], "default_owner": "0000000000000"}
+    {"name": "Base Path", "description": "Base path for Open Access to PEP", "resource_uri": "/", "scopes": ["protected_access"], "default_owner": "0000000000000"}
 
   ]
 }

--- a/src/blueprints/proxy.py
+++ b/src/blueprints/proxy.py
@@ -24,6 +24,7 @@ def construct_blueprint(oidc_client, uma_handler, g_config, private_key):
     logger = logging.getLogger("PEP_ENGINE")
     log_handler = LogHandler.get_instance()
 
+    @proxy_bp.route('/', defaults={'path': ''}, methods=["GET","POST","PUT","DELETE","HEAD","PATCH"])
     @proxy_bp.route("/<path:path>", methods=["GET","POST","PUT","DELETE","HEAD","PATCH"])
     def resource_request(path):
         # Check for token
@@ -47,9 +48,7 @@ def construct_blueprint(oidc_client, uma_handler, g_config, private_key):
                 scopes.append('protected_head')
             elif request.method == 'PATCH':
                 scopes.append('protected_patch')
-        
         uid = None
-        
         #If UUID exists and resource requested has same UUID
         api_rpt_uma_validation = g_config["api_rpt_uma_validation"]
     
@@ -93,7 +92,7 @@ def construct_blueprint(oidc_client, uma_handler, g_config, private_key):
         if resource_id is not None:
             try:
                 logger.debug("Matched resource: "+str(resource_id))
-                # Generate ticket if token is not present        
+                # Generate ticket if token is not present
                 ticket = uma_handler.request_access_ticket([{"resource_id": resource_id, "resource_scopes": scopes }])
                 # Return ticket
                 response.headers["WWW-Authenticate"] = "UMA realm="+g_config["realm"]+",as_uri="+g_config["auth_server_url"]+",ticket="+ticket


### PR DESCRIPTION
… The proxy wont return a 404 when the base path is being called, it was added a default empty value to the proxy endpoint in order to avoid the 404 code. Notice that the basePath is now registered with the protected_access scope by default so it will check if a user is an operator, if other scopes are selected it will give an error when retrieving the rpt. This may need to be updated in the dev-helm_charts repository